### PR TITLE
fix cmake policy issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.27)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 project(opt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ endif ()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
+# explicitly set cmake policy for find_package imports
+cmake_policy(SET CMP0144 NEW)
+
 include(GreenDeps)
 
 add_green_dependency(green-utils)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,5 @@
 project(opt-lib CXX)
 
-# explicitly set cmake policy for find_package imports
-cmake_policy(SET CMP0144 NEW)
-
 # Require version 3.4 to ensure compatibility with CUDA
 find_package(Eigen3 3.4 REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(opt-lib CXX)
 
+# explicitly set cmake policy for find_package imports
+cmake_policy(SET CMP0144 NEW)
+
 # Require version 3.4 to ensure compatibility with CUDA
 find_package(Eigen3 3.4 REQUIRED)
 


### PR DESCRIPTION
Addresses Cmake Policy issue #5 by enforcing:
1. minimum version of 3.27
2. explicitly setting cmake policy for find_package